### PR TITLE
Update last command to manage output history

### DIFF
--- a/language_spec.md
+++ b/language_spec.md
@@ -35,7 +35,7 @@ Truncated integer math. Division by zero yields 0.
 
 *bval* – pushes the bit counter onto the stack, and resets it.
 
-*\@last* - pops a value off the stack, uses that value as an index into the LAST-RUN output (modulused), pushes it on the stack.
+*\@last* - pops TWO values. First pop selects which history buffer to use (0 = most recent, 1 = previous, etc.) from a rolling history of the last 10 runs; second pop selects the index within that selected output (both indices are absoluted and modulused). Pushes the retrieved value (or 0 if missing) onto the stack.
 
 ### 📤 Output
 
@@ -71,7 +71,7 @@ Truncated integer math. Division by zero yields 0.
 
 ### 📦 Functions
 
-> \>name ... end
+> >name ... end
 
 * Define function name consisting of body ...
 

--- a/src/interpreter.htm
+++ b/src/interpreter.htm
@@ -56,7 +56,7 @@ const STEP_MS   = 200;    // mutation cadence (adjust to taste)
 let stepCount = 0;
 let stepPeg = 0;
 let bitCounter = 0;
-let lastOutput = [];
+let outputHistory = [];
 let targetSteps = 0;
 	
 const splitTok = t => {
@@ -372,11 +372,11 @@ function runWithOutput(src, debug = false) {
 		    if (blk.type === "loop" || blk.type === "once") th.callStack.pop();
 
                     if (blk.type === "loop" && --blk.remaining > 0) {
-          						th.blockStack.push({
-							...blk,
-							idx: 0
+           					th.blockStack.push({
+						...blk,
+						idx: 0
 						});
-			    			th.callStack.push(blk.label || "LOOP"); 
+				    	th.callStack.push(blk.label || "LOOP"); 
 					} else continue;
 				} else {
 					if (th.pc >= th.tokens.length) {
@@ -415,10 +415,10 @@ function runWithOutput(src, debug = false) {
 				else if (tok === "out") {
 				  let v;
 				  if (bitCounter > 0) {
-				    v = bitCounter;
-				    bitCounter = 0;
+					v = bitCounter;
+					bitCounter = 0;
 				  } else {
-				    v = pop();
+					v = pop();
 				  }
 					out.push(v);
 					const cs = th.callStack==null ? '' : th.callStack.join("|");
@@ -479,7 +479,7 @@ function runWithOutput(src, debug = false) {
 						tokens: blk,
 						idx: 0,
 						remaining: n
-     					   }); 
+      				   }); 
 					   th.callStack.push(labTok || "LOOP"); 
 					}
 				} else {
@@ -508,26 +508,36 @@ function runWithOutput(src, debug = false) {
 			if (tok.startsWith("@")) {
                 const name = tok.slice(1);
 		  // --- Novelty Anchors ---
-		if (name === "last") {
-			const idx = pop();
-			const val = lastOutput.length ? lastOutput[Math.abs(idx)%lastOutput.length] : 0;
-			S.push(CLAMP(val));
-			continue;
-		}
-   		 if (name === "time") {
-		    S.push(CLAMP(new Date().getSeconds()) % 10);
-		    // we favor external inputs like random and time
-		    inst = inst + ANCHOR_STEPS;
-		    continue;
-		  }
-		  if (name === "random") {
-		    S.push(CLAMP(Math.floor(Math.random() * 128)));
-		    // we favor external inputs like random and time
-		    inst = inst + ANCHOR_STEPS;
-		    continue;
-		  }		
+			if (name === "last") {
+				// pop: first = which history (0 = most recent), second = index within selected history
+				const historyIndexRaw = pop();
+				const innerIndexRaw = pop();
+				let val = 0;
+				const hLen = outputHistory.length;
+				if (hLen > 0) {
+					const which = Math.abs(historyIndexRaw) % hLen;
+					const selected = outputHistory.at(-1 - which) || [];
+					if (selected.length > 0) {
+						val = selected[Math.abs(innerIndexRaw) % selected.length] ?? 0;
+					}
+				}
+				S.push(CLAMP(val));
+				continue;
+			}
+	   		 if (name === "time") {
+			    S.push(CLAMP(new Date().getSeconds()) % 10);
+			    // we favor external inputs like random and time
+			    inst = inst + ANCHOR_STEPS;
+			    continue;
+			  }
+			  if (name === "random") {
+			    S.push(CLAMP(Math.floor(Math.random() * 128)));
+			    // we favor external inputs like random and time
+			    inst = inst + ANCHOR_STEPS;
+			    continue;
+			  }		
                 if (functions[name]) {
-		  const fn = functions[name];
+			  const fn = functions[name];
                   const p1 = pop(), p2 = pop(), p3 = pop();
                   S.push(p3, p2, p1);
                   th.blockStack.push({type:"func",tokens:[...fn.body],idx:0});
@@ -578,7 +588,9 @@ frameRef.idx = start;
   updateMetricsView(len, cc, lastCount);
   drawGraph(vals, cols, tips);
     updateLabelsView();  
-	lastOutput = [...out];
+	// Append this run's output to rolling history (cap at 10, 0 = most recent)
+	outputHistory.push([...out]);
+	if (outputHistory.length > 10) outputHistory.shift();
 	return out.join(" ");
 }
 


### PR DESCRIPTION
Update `@last` command to access a rolling history of the last 10 outputs instead of only the immediate last one.

---
<a href="https://cursor.com/background-agent?bcId=bc-2bdd9662-d2dc-4e5b-b45a-7aced8b80e55">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2bdd9662-d2dc-4e5b-b45a-7aced8b80e55">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

