### PR TITLE
Debug pressure calculation issue

### DIFF
--- a/src/interpreter.htm
+++ b/src/interpreter.htm
@@ -589,6 +589,14 @@ frameRef.idx = start;
   drawGraph(vals, cols, tips);
     updateLabelsView();  
 	// Append this run's output to rolling history (cap at 10, 0 = most recent)
+	// Compute and record stability pressure as Levenshtein distance from previous output
+	const prevOutArr = outputHistory.at(-1) || [];
+	const prevOutStr = Array.isArray(prevOutArr) ? prevOutArr.join(" ") : String(prevOutArr ?? "");
+	const currOutStr = out.join(" ");
+	pressureVal = levenshtein(prevOutStr, currOutStr);
+	pressureHist.push(pressureVal);
+	if (pressureHist.length > PRESS_WINDOW) pressureHist.shift();
+	updatePressure();
 	outputHistory.push([...out]);
 	if (outputHistory.length > 10) outputHistory.shift();
 	return out.join(" ");


### PR DESCRIPTION
Implement pressure calculation to fix the always-zero display.

The `pressureVal` was always zero because the `pressureHist` was never populated and `updatePressure()` was not called after runs. This PR adds the Levenshtein distance calculation between consecutive outputs, populates `pressureHist` with a rolling window, and updates the UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-0f06f690-3be3-42a4-b142-7486e2a5077a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0f06f690-3be3-42a4-b142-7486e2a5077a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

