### PR TITLE
Fix pressure calculation and implement running average

### DIFF
--- a/src/interpreter.htm
+++ b/src/interpreter.htm
@@ -177,7 +177,7 @@ function updateMutCount () {
 }
 
 let pressureVal = 0;                // last-measured stability pressure
-const PRESS_WINDOW = 20;        // size of the rolling window
+const PRESS_WINDOW = 10;        // size of the rolling window (last ~10 values)
 let   pressureHist = [];        // holds the most-recent values
 	
 function updatePressure () {        // refresh the UI
@@ -589,16 +589,8 @@ frameRef.idx = start;
   drawGraph(vals, cols, tips);
     updateLabelsView();  
 	// Append this run's output to rolling history (cap at 10, 0 = most recent)
-	// Compute and record stability pressure as Levenshtein distance from previous output
-	const prevOutArr = outputHistory.at(-1) || [];
-	const prevOutStr = Array.isArray(prevOutArr) ? prevOutArr.join(" ") : String(prevOutArr ?? "");
-	const currOutStr = out.join(" ");
-	pressureVal = levenshtein(prevOutStr, currOutStr);
-	pressureHist.push(pressureVal);
-	if (pressureHist.length > PRESS_WINDOW) pressureHist.shift();
-	updatePressure();
-	outputHistory.push([...out]);
-	if (outputHistory.length > 10) outputHistory.shift();
+  	outputHistory.push([...out]);
+  	if (outputHistory.length > 10) outputHistory.shift();
 	return out.join(" ");
 }
 
@@ -660,6 +652,7 @@ function mutateProgram() {
   const maxAttemptsPerDelta = 100;
 
   let deltaTokens = 1;
+  let totalAttempts = 0; // count how many mutation attempts are needed until one is accepted
 
   while (deltaTokens <= mutableIndices.length) {
     for (let attempt = 0; attempt < maxAttemptsPerDelta; attempt++) {
@@ -679,6 +672,7 @@ function mutateProgram() {
       }
 
       const newCode = mut.join(" ");
+      totalAttempts++;
       const newOut = runWithOutput(newCode);
       const newStep = stepCount;
  
@@ -687,6 +681,12 @@ function mutateProgram() {
         newOut !== origOut &&
         mut.length === origLen
       ) {
+        // Record pressure as attempts needed until an accepted mutation
+        pressureVal = totalAttempts;
+        pressureHist.push(pressureVal);
+        if (pressureHist.length > PRESS_WINDOW) pressureHist.shift();
+        updatePressure();
+
         document.getElementById("program").value = newCode;
         runProgram();
         return;
@@ -694,6 +694,12 @@ function mutateProgram() {
     }
     deltaTokens++;
   }
+
+  // No acceptable mutation found: record the pressure as total attempts tried
+  pressureVal = totalAttempts;
+  pressureHist.push(pressureVal);
+  if (pressureHist.length > PRESS_WINDOW) pressureHist.shift();
+  updatePressure();
 
   alert("No acceptable mutation found within constraints.");
 }


### PR DESCRIPTION
Refactor pressure calculation to measure mutation attempts until acceptance, displayed as a 10-value rolling average.

---
<a href="https://cursor.com/background-agent?bcId=bc-de5c36df-a8c4-47ef-b8d7-d19c56535b92">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-de5c36df-a8c4-47ef-b8d7-d19c56535b92">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

