### PR TITLE
Ensure mutation involves a command

### DIFF
--- a/src/interpreter.htm
+++ b/src/interpreter.htm
@@ -65,6 +65,20 @@ const splitTok = t => {
   return idx === -1 ? [t, null] : [t.slice(0, idx), t.slice(idx + 1)];
 };
 
+// Helpers to classify tokens and generate command tokens
+const isNumberToken = (tok) => {
+  const [base] = splitTok(tok);
+  return /^-?\d+$/.test(base);
+};
+const isCommandToken = (tok) => !isNumberToken(tok);
+function randNonNumberToken(valid = funcNames) {
+  let t;
+  do {
+    t = randToken(valid);
+  } while (isNumberToken(t));
+  return t;
+}
+
 const isControl = (tok) => {
   const [b] = splitTok(tok);
   return b === "loop" || b === "ifg" || b === "ifl" ||
@@ -663,12 +677,25 @@ function mutateProgram() {
         const idx = mutableIndices[Math.floor(Math.random() * mutableIndices.length)];
         indices.add(idx);
       }
+      let involvesCommand = false;
       for (const idx of indices) {
 	let newTok;
+        let oldTok = mut[idx];
         do {
           newTok = randToken();
-        } while (newTok === mut[idx]);
+        } while (newTok === oldTok);
+        if (isCommandToken(oldTok) || isCommandToken(newTok)) involvesCommand = true;
         mut[idx] = newTok;
+      }
+      // Ensure at least one mutated position involves a command
+      if (!involvesCommand) {
+        const forceIdx = Array.from(indices)[Math.floor(Math.random() * indices.size)];
+        let forced;
+        do {
+          forced = randNonNumberToken();
+        } while (forced === toks[forceIdx]);
+        mut[forceIdx] = forced;
+        involvesCommand = true;
       }
 
       const newCode = mut.join(" ");


### PR DESCRIPTION
Ensure program mutations always involve a command token to promote structural changes.

---
<a href="https://cursor.com/background-agent?bcId=bc-320a8965-645b-46a8-b558-c23193692654">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-320a8965-645b-46a8-b558-c23193692654">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

