### PR TITLE
Rename pressure to inertia and update rolling average

### DIFF
--- a/src/interpreter.htm
+++ b/src/interpreter.htm
@@ -25,7 +25,7 @@
 <button id="autoBtn" onclick="toggleAuto()">Start</button>
   <div style='margin-bottom: 10px;'>
 &nbsp;Generation: <span id="mutCount">0</span>
-&nbsp;|&nbsp;Pressure:&nbsp;<span id="pressureVal">0</span>
+&nbsp;|&nbsp;Inertia:&nbsp;<span id="inertiaVal">0</span>
   &nbsp;|&nbsp;Len: &nbsp;<span id="progLen">0</span>
 &nbsp;|&nbsp;CC:&nbsp;<span id="ccVal">0</span>
 &nbsp;|&nbsp;@last:&nbsp;<span id="lastCount">0</span>
@@ -140,9 +140,9 @@ function randToken(valid = funcNames){
 function generateRandomProgram() {
 	mutCount = 0;
 	updateMutCount();
-	pressureVal = 0;
-	pressureHist = [];
-	updatePressure();
+	    inertiaVal = 0;
+    inertiaHist = [];
+    updateInertia();
 	if (autoTimer) toggleAuto();   // ensure auto-evolve halts on Clear
 
 	const tot = 50,
@@ -190,17 +190,17 @@ function updateMutCount () {
   if (el) el.textContent = mutCount;
 }
 
-let pressureVal = 0;                // last-measured stability pressure
-const PRESS_WINDOW = 10;        // size of the rolling window (last ~10 values)
-let   pressureHist = [];        // holds the most-recent values
+let inertiaVal = 0;                // last-measured stability inertia
+const INERTIA_WINDOW = 20;        // size of the rolling window (last ~20 values)
+let   inertiaHist = [];        // holds the most-recent values
 	
-function updatePressure () {        // refresh the UI
+function updateInertia () {        // refresh the UI
   // compute mean of the window (default 0 if empty)
-  const mean = pressureHist.length
-        ? pressureHist.reduce((s,v) => s + v, 0) / pressureHist.length
+  const mean = inertiaHist.length
+        ? inertiaHist.reduce((s,v) => s + v, 0) / inertiaHist.length
         : 0;
 
-  const el = document.getElementById("pressureVal");
+  const el = document.getElementById("inertiaVal");
   if (el) el.textContent = mean.toFixed(1);      // one-decimal display
 }
 
@@ -708,11 +708,11 @@ function mutateProgram() {
         newOut !== origOut &&
         mut.length === origLen
       ) {
-        // Record pressure as attempts needed until an accepted mutation
-        pressureVal = totalAttempts;
-        pressureHist.push(pressureVal);
-        if (pressureHist.length > PRESS_WINDOW) pressureHist.shift();
-        updatePressure();
+        // Record inertia as attempts needed until an accepted mutation
+        inertiaVal = totalAttempts;
+        inertiaHist.push(inertiaVal);
+        if (inertiaHist.length > INERTIA_WINDOW) inertiaHist.shift();
+        updateInertia();
 
         document.getElementById("program").value = newCode;
         runProgram();
@@ -722,11 +722,11 @@ function mutateProgram() {
     deltaTokens++;
   }
 
-  // No acceptable mutation found: record the pressure as total attempts tried
-  pressureVal = totalAttempts;
-  pressureHist.push(pressureVal);
-  if (pressureHist.length > PRESS_WINDOW) pressureHist.shift();
-  updatePressure();
+  // No acceptable mutation found: record the inertia as total attempts tried
+  inertiaVal = totalAttempts;
+  inertiaHist.push(inertiaVal);
+  if (inertiaHist.length > INERTIA_WINDOW) inertiaHist.shift();
+  updateInertia();
 
   alert("No acceptable mutation found within constraints.");
 }


### PR DESCRIPTION
Rename 'pressure' to 'inertia' and update its rolling average window to 20 readings.

The 'pressure' measure was renamed to 'inertia' to more accurately reflect its meaning as the program's resistance to change under program-length and computational-depth constraints. The rolling average window for this measure was also updated from 10 to 20 readings for a more stable average.

---
<a href="https://cursor.com/background-agent?bcId=bc-ec1bba96-f763-4f9c-ba7d-4d0f144eea98">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ec1bba96-f763-4f9c-ba7d-4d0f144eea98">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

