### PR TITLE
Fix loop end statement execution

### DIFF
--- a/src/interpreter.htm
+++ b/src/interpreter.htm
@@ -571,12 +571,12 @@ function runWithOutput(src, debug = false, opts = {}) {
 					}
 				}
 				 // Splice only once, at top level, so nested loops remain intact
-				if (frameRef.tokens === th.tokens) {
-				   const blkStart = startBeforeCollect;
-				   const blkEnd   = frameRef.idx;          // idx after collect
-				   frameRef.tokens.splice(blkStart, blkEnd - blkStart);
-				   frameRef.idx = blkStart;
-				 }
+				                 if (frameRef.tokens === th.tokens) {
+                   const blkStart = startBeforeCollect;
+                   const blkEnd   = frameRef.idx;          // idx after collect
+                   frameRef.tokens.splice(blkStart, blkEnd - blkStart);
+                   th.pc = blkStart;
+                 }
 				continue;
 			}
 


### PR DESCRIPTION
Correctly reset the thread program counter (`th.pc`) after splicing out `loop`/`if` blocks to ensure instructions immediately following `end` execute.

Previously, the interpreter reset `frameRef.idx` after removing a control block, but the top-level execution uses `th.pc` for instruction fetching. This caused the instruction immediately after `end` to be skipped, leading to incorrect program flow.

---
<a href="https://cursor.com/background-agent?bcId=bc-01b55f50-ac8e-4e61-9f7d-859b1cea1e06">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-01b55f50-ac8e-4e61-9f7d-859b1cea1e06">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

