### PR TITLE
Visualize execution trace as colored stack

### DIFF
--- a/src/interpreter.htm
+++ b/src/interpreter.htm
@@ -7,7 +7,6 @@
     body{font-family:monospace;background:#111;color:#eee;padding:20px}
     textarea{width:100%;height:200px;background:#222;color:#0f0;border:1px solid #555;padding:10px;font-size:14px}
     button{margin:10px 10px 10px 0;padding:10px}
-    #output{background:#222;padding:10px;border:1px solid #555;white-space:pre-wrap;color:#0ff}
     #graph{background:#000;border:1px solid #555;width:100%;height:120px;display:block;margin-top:6px}
     #history{margin-top:20px;padding:10px;background:#111;border-top:1px solid #555}
     .saved-entry{background:#222;margin-bottom:10px;padding:10px;border:1px solid #444;white-space:pre-wrap}
@@ -34,7 +33,6 @@
     &nbsp;|&nbsp;Steps:&nbsp;<span id="stepCount">0</span>
     &nbsp;|&nbsp;Cost:&nbsp;<span id="cost">0</span>
   </div>
-  <div id="output"></div>  
   <svg id="graph"></svg>
 <div id="labelsArea">
   <h2>Labels</h2>
@@ -52,6 +50,8 @@ const ANCHOR_STEPS = 25;
 const CLAMP = v => ((v % 128) + 128) % 128;
 let LABELS = {};   // label-string  -> tokenIndex (-1 = missing)
 let EXECUTION_TRACE = [];
+const palette = ["#ff0", "#f0f", "#0ff", "#f80", "#0f0", "#08f", "#f44", "#fff", "#ccc", "#faa"];
+let traceHistory = [];
 
 let autoTimer   = null;   // holds setInterval handle
 let mutCount    = 0;      // shown in UI
@@ -256,13 +256,12 @@ function updateLabelsView () {
   list.innerHTML = html;
 }
 /******************** GRAPH RENDER *********************/
-function drawGraph(vals, cols, titles) {
+function drawGraph() {
 	const svg = document.getElementById("graph");
 	if (!svg) return;
 
-	const histories = outputHistory;
+	const histories = traceHistory;
 	const inertias = outputInertia;
-  const colorHist = outputColorHistory;
 	if (!histories.length) {
 		svg.innerHTML = "";
 		svg.style.height = "0px";
@@ -286,19 +285,28 @@ function drawGraph(vals, cols, titles) {
 	let g = "";
 	// Draw newest at the top, older moving down
 	for (let idx = histories.length - 1; idx >= 0; idx--) {
-		const rowVals = histories[idx] || [];
+		const rowTrace = histories[idx] || [];
 		const inertia = inertias[idx] ?? 0;
-    const rowCols = (colorHist && colorHist[idx]) || [];
 		const rowH = heightFromInertia(inertia);
-		const n = rowVals.length;
+		const n = rowTrace.length;
 		if (n > 0) {
 			const step = n > 0 ? W / n : W;
+			// compute max callstack depth for this row
+			let maxDepth = 0;
 			for (let j = 0; j < n; j++) {
-				const v = rowVals[j];
-				const a = CLAMP(v) / 127; // opacity 0..1 based on clamped value
+				const csStr = rowTrace[j].callStack || "";
+				const depth = csStr.length ? csStr.split("|").length : 0;
+				if (depth > maxDepth) maxDepth = depth;
+			}
+			for (let j = 0; j < n; j++) {
+				const entry = rowTrace[j];
+				const csStr = entry.callStack || "";
+				const depth = csStr.length ? csStr.split("|").length : 0;
+				const colorIdx = Math.abs(hashCode(`${entry.tid}-${csStr}`)) % palette.length;
+				const col = palette[colorIdx];
+				const a = maxDepth > 0 ? (depth / maxDepth) : 0;
 				const x = j * step;
-                const col = rowCols[j] || '#0ff';
-                g += `<rect x='${x}' y='${y}' width='${Math.max(1, step - 1)}' height='${rowH}' fill='${col}' fill-opacity='${a}'></rect>`;
+				g += `<rect x='${x}' y='${y}' width='${Math.max(1, step - 1)}' height='${rowH}' fill='${col}' fill-opacity='${a}'></rect>`;
 			}
 		}
 		y += rowH + GAP;
@@ -367,12 +375,11 @@ function runWithOutput(src, debug = false, opts = {}) {
 		blockStack: [],
 		fn: ""
 	}];
-	const out = [],
-		outHTML = [],
+	const out = [];
+	const outHTML = [],
 		vals = [],
 		cols = [],
 		tips = [];
-	const palette = ["#ff0", "#f0f", "#0ff", "#f80", "#0f0", "#08f", "#f44", "#fff", "#ccc", "#faa"];
 
 	function parseDefs(tok, table) {
     const body = [];
@@ -710,22 +717,25 @@ frameRef.idx = start;
 			if (!isNaN(num)) { S.push(CLAMP(num)); if (!dryRun) EXECUTION_TRACE.push({ tid: th.id, ip: origIndex, stack: S.join("|"), callStack: (th.callStack && th.callStack.length ? th.callStack.join("|") : "") }); }
 		}
 	}
-		if (!dryRun) document.getElementById("output").innerHTML = "Output: " + outHTML.join(" ");
+		// removed output DOM update
 	const { len, cc, lastCount } = getMetrics(tokens);
     stepCount = inst;
   if (!dryRun) updateMetricsView(len, cc, lastCount);
-  if (!dryRun) drawGraph(vals, cols, tips);
-  if (!dryRun) updateLabelsView();  
-	// Append this run's output to rolling history (cap at 20, 0 = most recent)
+	// Append this run's output and trace to rolling history (cap at 20, 0 = most recent)
   if (!dryRun) {
  	outputHistory.push([...out]);
  	outputInertia.push(inertiaVal || 0);
-  outputColorHistory.push([...cols]);
-  outputTitleHistory.push([...tips]);
+ 	outputColorHistory.push([]);
+ 	outputTitleHistory.push([]);
  	if (outputHistory.length > 20) outputHistory.shift();
  	if (outputInertia.length > 20) outputInertia.shift();
     if (outputColorHistory.length > 20) outputColorHistory.shift();
     if (outputTitleHistory.length > 20) outputTitleHistory.shift();
+    // new: store execution trace row for graph
+    traceHistory.push(EXECUTION_TRACE.map(e => ({ ...e })));
+    if (traceHistory.length > 20) traceHistory.shift();
+    drawGraph();
+    updateLabelsView();
   }
 	return out.join(" ");
 }


### PR DESCRIPTION
Visualize execution trace on graph instead of output and remove output display.

The graph now represents the execution trace, with each row showing a run's trace and blocks colored by thread/callstack hash and opacified by callstack depth, providing a detailed view of program execution.

---
<a href="https://cursor.com/background-agent?bcId=bc-272569d3-aa95-49aa-9572-f3f5cf1ca3c4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-272569d3-aa95-49aa-9572-f3f5cf1ca3c4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

