### PR TITLE
Clamp graph fill opacity to be visible

### DIFF
--- a/src/interpreter.htm
+++ b/src/interpreter.htm
@@ -304,7 +304,8 @@ function drawGraph() {
 				const depth = csStr.length ? csStr.split("|").length : 0;
 				const colorIdx = Math.abs(hashCode(`${entry.tid}-${csStr}`)) % palette.length;
 				const col = palette[colorIdx];
-				const a = maxDepth > 0 ? (depth / maxDepth) : 0;
+				const rawOpacity = maxDepth > 0 ? (depth / maxDepth) : 0;
+				const a = Math.min(1, Math.max(0.2, rawOpacity));
 				const x = j * step;
 				g += `<rect x='${x}' y='${y}' width='${Math.max(1, step - 1)}' height='${rowH}' fill='${col}' fill-opacity='${a}'></rect>`;
 			}


### PR DESCRIPTION
Clamp graph fill opacity between 0.2 and 1 to ensure bars are always visible.

---
<a href="https://cursor.com/background-agent?bcId=bc-d3caee5b-32ff-4aea-b7f7-36b8135b7192">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d3caee5b-32ff-4aea-b7f7-36b8135b7192">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

