### PR TITLE
Update layout and create trace3d widget

### DIFF
--- a/src/interpreter.htm
+++ b/src/interpreter.htm
@@ -7,7 +7,10 @@
     body{font-family:monospace;background:#111;color:#eee;padding:20px}
     textarea{width:100%;height:200px;background:#222;color:#0f0;border:1px solid #555;padding:10px;font-size:14px}
     button{margin:10px 10px 10px 0;padding:10px}
-    #graph{background:#000;border:1px solid #555;width:100%;height:120px;display:block;margin-top:6px}
+    /* updated graph to half width and added companion 3D area */
+    #graph{background:#000;border:1px solid #555;width:50%;height:120px;display:block;margin-top:6px}
+    .graph-trace-row{display:flex;gap:10px}
+    #trace3d{background:#000;border:1px solid #555;width:50%;height:120px;display:block;margin-top:6px;position:relative;overflow:hidden}
     #history{margin-top:20px;padding:10px;background:#111;border-top:1px solid #555}
     .saved-entry{background:#222;margin-bottom:10px;padding:10px;border:1px solid #444;white-space:pre-wrap}
   </style>
@@ -33,7 +36,10 @@
     &nbsp;|&nbsp;Steps:&nbsp;<span id="stepCount">0</span>
     &nbsp;|&nbsp;Cost:&nbsp;<span id="cost">0</span>
   </div>
-  <svg id="graph"></svg>
+  <div class="graph-trace-row">
+    <svg id="graph"></svg>
+    <div id="trace3d"></div>
+  </div>
 <div id="labelsArea">
   <h2>Labels</h2>
   <div id="labelsList" style="white-space:pre-wrap"></div>
@@ -520,13 +526,13 @@ function runWithOutput(src, debug = false, opts = {}) {
 					}
 				}
 				else if (tok === "out") {
-				  let v;
-				  if (bitCounter > 0) {
-					v = bitCounter;
-					bitCounter = 0;
-				  } else {
-					v = pop();
-				  }
+					let v;
+					if (bitCounter > 0) {
+						v = bitCounter;
+						bitCounter = 0;
+					} else {
+						v = pop();
+					}
 					out.push(v);
 					const cs = th.callStack==null ? '' : th.callStack.join("|");
 					const idx = Math.abs(hashCode(`${th.id}-${cs}`)) % palette.length;
@@ -592,7 +598,7 @@ function runWithOutput(src, debug = false, opts = {}) {
               indices: blk.indices,
 						idx: 0,
 						remaining: n
-		    	   }); 
+			    	   }); 
 					   th.callStack.push(labTok || "LOOP"); 
 					}
 				} else {
@@ -605,18 +611,18 @@ function runWithOutput(src, debug = false, opts = {}) {
 						tokens: blk.tokens,
               indices: blk.indices,
 						idx: 0
-			  				}); 
+				  			}); 
 						th.callStack.push(labTok || tok.toUpperCase()); 
 					}
 				}
 				 // Splice only once, at top level, so nested loops remain intact
 				                 if (frameRef.tokens === th.tokens) {
-		           const blkStart = startBeforeCollect;
-		           const blkEnd   = frameRef.idx;          // idx after collect
-		           frameRef.tokens.splice(blkStart, blkEnd - blkStart);
+			           const blkStart = startBeforeCollect;
+			           const blkEnd   = frameRef.idx;          // idx after collect
+			           frameRef.tokens.splice(blkStart, blkEnd - blkStart);
                  frameRef.indices.splice(blkStart, blkEnd - blkStart);
-		           th.pc = blkStart;
-		         }
+			           th.pc = blkStart;
+			         }
           if (!dryRun) EXECUTION_TRACE.push({ tid: th.id, ip: origIndex, stack: S.join("|"), callStack: (th.callStack && th.callStack.length ? th.callStack.join("|") : "") });
 				continue;
 			}
@@ -1140,5 +1146,8 @@ window.onload = () => {
 	updateMutCount();   // initialise counter to 0 on first load
 };
 </script> 
+<!-- include three.js and the trace3d widget -->
+<script src="https://unpkg.com/three@0.158.0/build/three.min.js"></script>
+<script src="./trace3d.js"></script>
 </body> 
 </html>

--- a/src/trace3d.js
+++ b/src/trace3d.js
@@ -1,0 +1,108 @@
+(function(){
+  if (typeof THREE === 'undefined') {
+    console.warn('THREE not found; trace3d will not initialize.');
+    return;
+  }
+
+  function initTrace3D() {
+    const container = document.getElementById('trace3d');
+    if (!container) return;
+
+    // Create renderer
+    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+    renderer.setSize(container.clientWidth, container.clientHeight, false);
+    renderer.domElement.style.width = '100%';
+    renderer.domElement.style.height = '100%';
+    container.appendChild(renderer.domElement);
+
+    // Scene and camera
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(
+      45,
+      Math.max(1, container.clientWidth) / Math.max(1, container.clientHeight),
+      0.1,
+      100
+    );
+    camera.position.set(0, 0, 3);
+
+    // Lights
+    scene.add(new THREE.AmbientLight(0xffffff, 0.6));
+    const dir = new THREE.DirectionalLight(0xffffff, 0.8);
+    dir.position.set(5, 8, 6);
+    scene.add(dir);
+
+    // Translucent sphere
+    const geom = new THREE.SphereGeometry(1, 48, 32);
+    const mat = new THREE.MeshStandardMaterial({
+      color: 0x44aaff,
+      transparent: true,
+      opacity: 0.35,
+      metalness: 0.1,
+      roughness: 0.2,
+      depthWrite: false
+    });
+    const sphere = new THREE.Mesh(geom, mat);
+    scene.add(sphere);
+
+    // Optional subtle wireframe for shape definition
+    const wire = new THREE.LineSegments(
+      new THREE.WireframeGeometry(geom),
+      new THREE.LineBasicMaterial({ color: 0x88ccff, opacity: 0.25, transparent: true })
+    );
+    sphere.add(wire);
+
+    // Animation loop
+    let animId = 0;
+    function animate() {
+      animId = requestAnimationFrame(animate);
+      sphere.rotation.y += 0.01;
+      sphere.rotation.x += 0.005;
+      renderer.render(scene, camera);
+    }
+
+    // Resizing
+    function resize() {
+      const w = Math.max(1, container.clientWidth);
+      const h = Math.max(1, container.clientHeight);
+      renderer.setSize(w, h, false);
+      camera.aspect = w / h;
+      camera.updateProjectionMatrix();
+    }
+
+    const ro = new ResizeObserver(resize);
+    ro.observe(container);
+
+    // Keep 3D view height in sync with graph height when it changes
+    const graph = document.getElementById('graph');
+    if (graph) {
+      const sync = () => {
+        const gh = graph.clientHeight;
+        if (gh > 0) container.style.height = gh + 'px';
+      };
+      const gro = new ResizeObserver(sync);
+      gro.observe(graph);
+      // initial sync
+      sync();
+    }
+
+    // Start
+    resize();
+    animate();
+
+    // Cleanup on unload
+    window.addEventListener('beforeunload', () => {
+      cancelAnimationFrame(animId);
+      ro.disconnect();
+      renderer.dispose();
+      geom.dispose();
+      mat.dispose();
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initTrace3D, { once: true });
+  } else {
+    initTrace3D();
+  }
+})();


### PR DESCRIPTION
Adds a 3D visualization placeholder (`trace3d.js`) with a rotating sphere and updates `interpreter.htm` to display it in a 50/50 split next to the graph.

---
<a href="https://cursor.com/background-agent?bcId=bc-6dd0ef53-550b-4302-a30d-5c1032eeeb6a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6dd0ef53-550b-4302-a30d-5c1032eeeb6a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

