### PR TITLE
Set trace3d height and layout points

### DIFF
--- a/src/interpreter.htm
+++ b/src/interpreter.htm
@@ -10,7 +10,7 @@
     /* updated graph to half width and added companion 3D area */
     #graph{background:#000;border:1px solid #555;width:50%;height:120px;display:block;margin-top:6px}
     .graph-trace-row{display:flex;gap:10px}
-    #trace3d{background:#000;border:1px solid #555;width:50%;height:120px;display:block;margin-top:6px;position:relative;overflow:hidden}
+    #trace3d{background:#000;border:1px solid #555;width:50%;min-height:620px;max-height:620px;height:620px;display:block;margin-top:6px;position:relative;overflow:hidden}
     #history{margin-top:20px;padding:10px;background:#111;border-top:1px solid #555}
     .saved-entry{background:#222;margin-bottom:10px;padding:10px;border:1px solid #444;white-space:pre-wrap}
   </style>
@@ -234,6 +234,7 @@ function toggleAuto () {
   // ----- START -----
   btn.textContent = "Stop";
   targetSteps = stepCount;
+  try { if (window.Trace3D && typeof window.Trace3D.setup === 'function') window.Trace3D.setup(EXECUTION_TRACE); } catch (e) { /* no-op */ }
   autoTimer = setInterval(() => {
     const lost = Object.values(LABELS).some(v => v === -1);
     if (lost) {                    // stop if any label vanished
@@ -753,6 +754,7 @@ const savedPrograms = [];
 function runProgram(d = false) {
 	const code = document.getElementById("program").value.trim();
 	runWithOutput(code, d);
+	try { if (window.Trace3D && typeof window.Trace3D.setup === 'function') window.Trace3D.setup(EXECUTION_TRACE); } catch (e) { /* no-op */ }
 }
 
 function saveProgram() {

--- a/src/trace3d.js
+++ b/src/trace3d.js
@@ -4,12 +4,18 @@
     return;
   }
 
+  // shared state for the widget
+  let container, renderer, scene, camera, sphere;
+  let pointsGroup;
+  const traceIndexToObject = new Map();
+  let sharedPointGeometry = null;
+
   function initTrace3D() {
-    const container = document.getElementById('trace3d');
+    container = document.getElementById('trace3d');
     if (!container) return;
 
     // Create renderer
-    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+    renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
     renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
     renderer.setSize(container.clientWidth, container.clientHeight, false);
     renderer.domElement.style.width = '100%';
@@ -17,8 +23,8 @@
     container.appendChild(renderer.domElement);
 
     // Scene and camera
-    const scene = new THREE.Scene();
-    const camera = new THREE.PerspectiveCamera(
+    scene = new THREE.Scene();
+    camera = new THREE.PerspectiveCamera(
       45,
       Math.max(1, container.clientWidth) / Math.max(1, container.clientHeight),
       0.1,
@@ -42,7 +48,7 @@
       roughness: 0.2,
       depthWrite: false
     });
-    const sphere = new THREE.Mesh(geom, mat);
+    sphere = new THREE.Mesh(geom, mat);
     scene.add(sphere);
 
     // Optional subtle wireframe for shape definition
@@ -51,6 +57,10 @@
       new THREE.LineBasicMaterial({ color: 0x88ccff, opacity: 0.25, transparent: true })
     );
     sphere.add(wire);
+
+    // Points container
+    pointsGroup = new THREE.Group();
+    scene.add(pointsGroup);
 
     // Animation loop
     let animId = 0;
@@ -73,19 +83,6 @@
     const ro = new ResizeObserver(resize);
     ro.observe(container);
 
-    // Keep 3D view height in sync with graph height when it changes
-    const graph = document.getElementById('graph');
-    if (graph) {
-      const sync = () => {
-        const gh = graph.clientHeight;
-        if (gh > 0) container.style.height = gh + 'px';
-      };
-      const gro = new ResizeObserver(sync);
-      gro.observe(graph);
-      // initial sync
-      sync();
-    }
-
     // Start
     resize();
     animate();
@@ -99,6 +96,109 @@
       mat.dispose();
     });
   }
+
+  // Generate a random unit vector and radius with uniform volume distribution
+  function randomPointInUnitSphere() {
+    // Uniform on sphere surface
+    const u = Math.random();
+    const v = Math.random();
+    const theta = 2 * Math.PI * u;
+    const z = 2 * v - 1; // in [-1,1]
+    const rXY = Math.sqrt(Math.max(0, 1 - z * z));
+    const x = rXY * Math.cos(theta);
+    const y = rXY * Math.sin(theta);
+    // Uniform radius in volume
+    const r = Math.cbrt(Math.random());
+    return new THREE.Vector3(x * r, y * r, z * r);
+  }
+
+  // Semi-random layout that progressively spreads points throughout the sphere interior
+  function layoutPoints(count) {
+    const positions = [];
+    // Adjust candidate count to keep cost reasonable for large N
+    const candidatesPerPoint = count > 1000 ? 3 : count > 300 ? 5 : 10;
+
+    for (let i = 0; i < count; i++) {
+      let bestVec = null;
+      let bestScore = -Infinity;
+      for (let c = 0; c < candidatesPerPoint; c++) {
+        const candidate = randomPointInUnitSphere();
+        // score = distance to nearest existing point (maximize to spread)
+        let minDist = Infinity;
+        for (let j = 0; j < positions.length; j++) {
+          const d = candidate.distanceTo(positions[j]);
+          if (d < minDist) minDist = d;
+          if (minDist === 0) break;
+        }
+        const score = positions.length === 0 ? 1 : minDist;
+        if (score > bestScore) {
+          bestScore = score;
+          bestVec = candidate;
+        }
+      }
+      positions.push(bestVec || randomPointInUnitSphere());
+    }
+
+    return positions;
+  }
+
+  function clearPoints() {
+    if (!pointsGroup) return;
+    for (let i = pointsGroup.children.length - 1; i >= 0; i--) {
+      const child = pointsGroup.children[i];
+      pointsGroup.remove(child);
+      if (child.material) child.material.dispose?.();
+      // sharedPointGeometry is reused
+    }
+    traceIndexToObject.clear();
+  }
+
+  function setup(executionTrace) {
+    if (!scene || !pointsGroup || !Array.isArray(executionTrace)) return;
+
+    clearPoints();
+
+    const count = executionTrace.length | 0;
+    if (count <= 0) return;
+
+    // Create shared geometry for tiny spheres
+    if (!sharedPointGeometry) sharedPointGeometry = new THREE.SphereGeometry(0.02, 8, 6);
+
+    // Pre-compute positions
+    const positions = layoutPoints(count);
+
+    // Optional: map thread ids to consistent colors
+    const tidSet = new Map();
+    let nextHue = 0;
+    const getColorForTid = (tid) => {
+      if (!tidSet.has(tid)) {
+        tidSet.set(tid, nextHue);
+        nextHue = (nextHue + 47) % 360; // hop hues for variety
+      }
+      const hue = tidSet.get(tid);
+      const color = new THREE.Color();
+      color.setHSL(hue / 360, 0.6, 0.6);
+      return color;
+    };
+
+    for (let i = 0; i < count; i++) {
+      const pos = positions[i];
+      const entry = executionTrace[i] || {};
+      const color = getColorForTid(entry.tid == null ? i : entry.tid);
+      const mat = new THREE.MeshStandardMaterial({ color, emissive: color.clone().multiplyScalar(0.2) });
+      const m = new THREE.Mesh(sharedPointGeometry, mat);
+      m.position.copy(pos);
+      pointsGroup.add(m);
+      traceIndexToObject.set(i, m);
+    }
+  }
+
+  // expose API
+  window.Trace3D = {
+    setup,
+    layoutPoints,
+    getObjectForTraceIndex: (idx) => traceIndexToObject.get(idx) || null
+  };
 
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', initTrace3D, { once: true });


### PR DESCRIPTION
Fix `trace3d` height and add execution trace visualization as progressively spread points within the 3D sphere.

The user requested a fixed height for the 3D visualization area and a new feature to represent the execution trace as a series of points inside the sphere. These points are laid out semi-randomly, progressively spreading to avoid clumping, and are generated upon program execution (Run/Start). This provides a visual representation of the program's trace within the 3D environment.

---
<a href="https://cursor.com/background-agent?bcId=bc-f125824f-4ef5-4a80-b6f2-ce14603c81da">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f125824f-4ef5-4a80-b6f2-ce14603c81da">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

