### PR TITLE
Fix target point highlight in trace3d

### DIFF
--- a/src/trace3d.js
+++ b/src/trace3d.js
@@ -521,9 +521,9 @@
       const f = 1 - t; // 1 at hit, 0 at end
       // Color fades from highlight to base
       mat.color.copy(baseColor).lerp(TARGET_HIGHLIGHT_COLOR, f);
-      // Emissive brightness fades from strong to base
+      // Emissive brightness and hue fade from highlight to base
       const emissiveFactor = baseEmissiveMin + (1.0 - baseEmissiveMin) * f;
-      mat.emissive.copy(baseColor).multiplyScalar(emissiveFactor);
+      mat.emissive.copy(baseColor).lerp(TARGET_HIGHLIGHT_COLOR, f).multiplyScalar(emissiveFactor);
 
       if (t >= 1) {
         // Restore base and stop tracking


### PR DESCRIPTION
Make the target highlight visibly orange by blending the emissive color during the flash.

The original implementation only blended the base color to orange, but the emissive color remained blue and at high intensity, visually obscuring the intended orange highlight. This change ensures the emissive color also transitions to orange, making the highlight clearly visible.

---
<a href="https://cursor.com/background-agent?bcId=bc-d92521b6-c1e6-47f1-a8b9-97d2a64df471">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d92521b6-c1e6-47f1-a8b9-97d2a64df471">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

