### PR TITLE
Make interpreter.htm responsive for mobile

### DIFF
--- a/src/interpreter.htm
+++ b/src/interpreter.htm
@@ -2,10 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Cachi‑Forth Interpreter</title>
   <style> 
-    body{font-family:monospace;background:#111;color:#eee;padding:20px}
-    textarea{width:100%;height:200px;background:#222;color:#0f0;border:1px solid #555;padding:10px;font-size:14px}
+    body{font-family:system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;background:#111;color:#eee;padding:20px}
+    textarea{width:100%;height:200px;background:#222;color:#0f0;border:1px solid #555;padding:10px;font-size:14px;font-family:monospace}
     button{margin:10px 10px 10px 0;padding:10px}
     /* updated graph to half width and added companion 3D area */
     #graph{background:#000;border:1px solid #555;width:50%;height:120px;display:block;margin-top:6px}
@@ -14,6 +15,12 @@
     #history{margin-top:20px;padding:10px;background:#111;border-top:1px solid #555}
     .saved-entry{background:#222;margin-bottom:10px;padding:10px;border:1px solid #444;white-space:pre-wrap}
 	#program { height: 50px }
+
+  @media (max-width: 768px) {
+    .graph-trace-row { flex-direction: column; }
+    #trace3d { order: -1; width: 100%; }
+    #graph { width: 100%; }
+  }
   </style>
 </head>
 <body>


### PR DESCRIPTION
Make `interpreter.htm` responsive for mobile by reordering visualizations and updating the font.

---
<a href="https://cursor.com/background-agent?bcId=bc-24f133f0-d7c7-4cf2-aeed-40f6c2acb698">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-24f133f0-d7c7-4cf2-aeed-40f6c2acb698">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

