### PR TITLE
Stop auto mutation when survival cost target met

### DIFF
--- a/src/interpreter.htm
+++ b/src/interpreter.htm
@@ -319,6 +319,14 @@ function toggleAuto () {
       toggleAuto();
       return;
     }
+    if (survivalMode) {
+      const target = targetCost==0 ? lastRunCost : targetCost;
+      const maxDelta = Math.ceil(target * 0.05);
+      if (Math.abs(lastRunCost - target) <= maxDelta) {
+        toggleAuto();
+        return;
+      }
+    }
     mutateProgram();               // perform one mutation
     mutCount++;
     updateMutCount();


### PR DESCRIPTION
## Summary
- Avoid further mutations in survival mode once complexity cost is within 5% of target

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a622c3701c8329be7c9c23ea0075b6