### PR TITLE
Implement map2 to map5 instructions

### DIFF
--- a/src/interpreter.htm
+++ b/src/interpreter.htm
@@ -126,7 +126,8 @@ const isControl = (tok) => {
   const [b] = splitTok(tok);
   return b === "loop" || b === "ifg" || b === "ifl" ||
          (b.startsWith("@") && b.length > 1) ||                      // function call
-         (b.startsWith("branch") && b.length === 7);
+         (b.startsWith("branch") && b.length === 7) ||
+         (b.startsWith("map") && b.length === 4);
 };
 
 function hashCode(str) {
@@ -153,7 +154,7 @@ function levenshtein(a, b) {
 
 /******************** TOKEN POOLS *********************/
 const instrPool = ["+", "-", "*", "/", "dup", "swap", "bit", "bval", "out", "prune"];
-const ctrlPool = ["loop", "ifg", "ifl", "branch2", "branch3", "branch4", "branch5"];
+const ctrlPool = ["loop", "ifg", "ifl", "branch2", "branch3", "branch4", "branch5", "map2", "map3", "map4", "map5"];
 const funcNames = ["func1", "func2", "func3", "func4", "func5"];
 
 /******************** RANDOM TOKEN / PROGRAM *********************/
@@ -168,7 +169,8 @@ function randToken(valid = funcNames){
   }
   // 25% chance: control / function tokens
   const branchTokens = ["branch2","branch3","branch4"]; // restrict to branch2‑4
-  const controlTokens = ["loop","ifg","ifl",...branchTokens];
+  const mapTokens = ["map2", "map3", "map4"]; // restrict to map2-4
+  const controlTokens = ["loop","ifg","ifl",...branchTokens,...mapTokens];
   // Limit function space to first 3 names to keep total distinct functions small
   const limitedFuncs = valid.slice(0,3);
   const pool = [
@@ -223,6 +225,10 @@ function generateRandomProgram() {
     else if (base.startsWith("branch") && base.length === 7) {
       const n = +base[6];
       if (n >= 2 && n <= 5) cc += n - 1;  // branch2 ⇒ +1, branch3 ⇒ +2 …
+    }
+    else if (base.startsWith("map") && base.length === 4) {
+      const n = +base[3];
+      if (n >= 2 && n <= 5) cc += n - 1;  // map2 ⇒ +1, map3 ⇒ +2 …
     }
     else if (base === "@last") lastCount += 1;  // count @last commands
   }
@@ -841,6 +847,70 @@ frameRef.idx = start;
           if (!dryRun) EXECUTION_TRACE.push({ tid: th.id, ip: origIndex, stack: S.join("|"), callStack: (th.callStack && th.callStack.length ? th.callStack.join("|") : "") });
 			continue;
 		}
+
+			// Handle map2, map3, map4, map5 instructions
+			if (tok.startsWith("map") && tok.length === 4) {
+				const N = +tok[3];
+				if (N >= 2 && N <= 5) {
+					// Pop N values from the stack
+					const values = [];
+					for (let i = 0; i < N; i++) {
+						values.unshift(pop()); // unshift to maintain stack order
+					}
+					
+					// Save the current stack state after popping values
+					const baseStack = [...S];
+					
+					// Collect the next instruction/block
+					const seedStartIndex = frameRef.idx;
+					const seed = collectSeed(frameRef);
+					
+					// Remove the collected seed from the current frame
+					const start = seedStartIndex;
+					const end = frameRef.idx;
+					frameRef.tokens.splice(start, end - start);
+					frameRef.indices.splice(start, end - start);
+					frameRef.idx = start;
+					
+					// If operating on main stream, adjust pc
+					if (frameRef.tokens === th.tokens) {
+						th.pc = start;
+					}
+					
+					// For each value, create a thread with the base stack plus the value
+					for (let i = 0; i < values.length; i++) {
+						const value = values[i];
+						
+						if (i === 0) {
+							// Use current thread for first value
+							S.push(value); // Push the value onto stack
+							
+							// Insert seed tokens into current position
+							const top = th.blockStack.length ? th.blockStack[th.blockStack.length - 1]
+							                                  : { tokens: th.tokens, indices: th.indices, idx: start };
+							top.tokens.splice(top.idx, 0, ...seed.tokens);
+							top.indices.splice(top.idx, 0, ...seed.indices);
+						} else {
+							// Clone thread with base stack state for remaining values
+							const clone = JSON.parse(JSON.stringify(th));
+							// Reset clone's stack to base state and add the value
+							clone.stack = [...baseStack, value];
+							
+							// Insert seed tokens
+							const top = clone.blockStack.length ? clone.blockStack[clone.blockStack.length - 1]
+							                                    : { tokens: clone.tokens, indices: clone.indices, idx: start };
+							top.tokens.splice(top.idx, 0, ...seed.tokens);
+							top.indices.splice(top.idx, 0, ...seed.indices);
+							
+							clone.pc = start;
+							clone.id = nextThreadId++;
+							threads.push(clone);
+						}
+					}
+				}
+				if (!dryRun) EXECUTION_TRACE.push({ tid: th.id, ip: origIndex, stack: S.join("|"), callStack: (th.callStack && th.callStack.length ? th.callStack.join("|") : "") });
+				continue;
+			}
 
 			const num = parseInt(tok, 10);
 			if (!isNaN(num)) { S.push(CLAMP(num)); if (!dryRun) EXECUTION_TRACE.push({ tid: th.id, ip: origIndex, stack: S.join("|"), callStack: (th.callStack && th.callStack.length ? th.callStack.join("|") : "") }); }

--- a/test_map.html
+++ b/test_map.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Map Instruction Test</title>
+</head>
+<body>
+    <h1>Map Instruction Test</h1>
+    <pre id="output"></pre>
+    
+    <script>
+        // Minimal interpreter implementation to test map logic
+        const CLAMP = v => ((v % 128) + 128) % 128;
+        
+        function runTest(code) {
+            const tokens = code.trim().split(/\s+/);
+            const stack = [];
+            const output = [];
+            let pc = 0;
+            
+            const pop = () => stack.pop() ?? 0;
+            const push = (v) => stack.push(CLAMP(v));
+            
+            function executeTokens(tokens, stack, startPc = 0) {
+                let localPc = startPc;
+                
+                while (localPc < tokens.length) {
+                    const tok = tokens[localPc++];
+                    
+                    if (tok === '+') {
+                        const b = pop(), a = pop();
+                        push(a + b);
+                    } else if (tok === 'out') {
+                        output.push(pop());
+                    } else if (tok.startsWith('map') && tok.length === 4) {
+                        const N = +tok[3];
+                        const values = [];
+                        for (let i = 0; i < N; i++) {
+                            values.unshift(pop());
+                        }
+                        
+                        // Get next instruction
+                        const nextInstr = tokens[localPc++];
+                        
+                        // Execute the instruction for each value
+                        for (const value of values) {
+                            const clonedStack = [...stack];
+                            clonedStack.push(value);
+                            
+                            // Execute the next instruction with cloned stack
+                            if (nextInstr === '+') {
+                                const b = clonedStack.pop() ?? 0;
+                                const a = clonedStack.pop() ?? 0;
+                                stack.push(CLAMP(a + b));
+                            } else if (nextInstr === 'out') {
+                                output.push(clonedStack.pop() ?? 0);
+                            }
+                        }
+                    } else {
+                        // Number
+                        const num = parseInt(tok, 10);
+                        if (!isNaN(num)) {
+                            push(num);
+                        }
+                    }
+                }
+                
+                return { stack, output };
+            }
+            
+            // Initialize stack
+            stack.push(10);
+            
+            const result = executeTokens(tokens, stack);
+            return result.output;
+        }
+        
+        // Test the example: 10 5 2 map2 + out out
+        const testCode = "5 2 map2 + out out";
+        const result = runTest(testCode);
+        
+        document.getElementById('output').textContent = 
+            `Test: 10 ${testCode}\n` +
+            `Expected output: 15, 12\n` +
+            `Actual output: ${result.join(', ')}\n` +
+            `Test ${result[0] === 15 && result[1] === 12 ? 'PASSED' : 'FAILED'}`;
+    </script>
+</body>
+</html>

--- a/test_map_example.txt
+++ b/test_map_example.txt
@@ -1,0 +1,32 @@
+Test cases for map instructions:
+
+1. Basic map2 example (from the requirement):
+   Input: 10 5 2 map2 + out out
+   Expected output: 15 12
+   
+   Explanation:
+   - Stack starts with [10]
+   - Push 5 and 2: [10, 5, 2]
+   - map2 pops 2 values (5, 2) leaving [10]
+   - For value 5: clone stack [10], push 5 → [10, 5], execute +, result 15
+   - For value 2: clone stack [10], push 2 → [10, 2], execute +, result 12
+   - Both results pushed to main stack
+   - out out prints: 15 12
+
+2. map3 with function call:
+   Input: >func1 + end 10 5 3 1 map3 @func1 out out out
+   Expected output: 15 13 11
+   
+3. map4 example:
+   Input: 100 4 3 2 1 map4 - out out out out
+   Expected output: 96 97 98 99
+   
+4. map with control structure:
+   Input: 10 20 2 map2 ifg 100 out end out out
+   Expected: 100 (nothing) - first thread executes ifg with 20>10, second with 10>10 (false)
+
+To test in the interpreter:
+1. Open interpreter.htm in a browser
+2. Enter the test code in the textarea
+3. Click "Run"
+4. Check the output matches expected results


### PR DESCRIPTION
Add `map2`, `map3`, `map4`, `map5` instructions to apply an operation to multiple stack values concurrently, collecting all results.

---
<a href="https://cursor.com/background-agent?bcId=bc-3d218f6b-3f91-4245-8df2-03021d9d66fa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3d218f6b-3f91-4245-8df2-03021d9d66fa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

