### PR TITLE
Add multiple swap and duplicate stack operations

### DIFF
--- a/src/interpreter.htm
+++ b/src/interpreter.htm
@@ -651,13 +651,32 @@ function runWithOutput(src, debug = false, opts = {}) {
 			inst++;
 			if (debug) console.log(`[T${th.id}] ${tok} [${S.join(',')}]`);
 			// primitives
-			if (["+", "-", "*", "/", "dup", "swap", "drop", "out", "bit", "bval", "prune"].includes(tok)) {
-				if (tok === "dup") S.push(S.at(-1) ?? 0);
+			if (["+", "-", "*", "/", "dup", "swap", "drop", "out", "bit", "bval", "prune"].includes(tok) || (tok.startsWith("dup") && tok.length === 4) || (tok.startsWith("swap") && tok.length === 5)) {
+				if (tok === "dup") {
+					const v = pop();
+					S.push(v, v);
+				}
+				else if (tok.length === 4 && tok.startsWith("dup")) {
+					let N = +tok[3];
+					if (!(N >= 1 && N <= 9)) N = 1;
+					const vals = [];
+					for (let i = 0; i < N; i++) vals.unshift(pop());
+					S.push(...vals, ...vals);
+				}
 				else if (tok === "swap") {
 					let b = pop(),
 						a = pop();
 					S.push(b, a);
-				} else if (tok === "drop") pop();
+				}
+				else if (tok.length === 5 && tok.startsWith("swap")) {
+					let N = +tok[4];
+					if (!(N >= 1 && N <= 9)) N = 1;
+					const v = pop();
+					let insertAt = S.length - N;
+					if (insertAt < 0) insertAt = 0;
+					S.splice(insertAt, 0, v);
+				}
+				else if (tok === "drop") pop();
 				else if (tok === "bit") bitCounter++;
 				else if (tok === "bval") { S.push(bitCounter); bitCounter = 0; }
 				else if (tok === "prune") {


### PR DESCRIPTION
Implement `swapN` and `dupN` instructions in `interpreter.htm` to provide more flexible stack manipulation.

The `swapN` instructions (e.g., `swap1` to `swap9`, with `swap` acting as `swap1`) pop the top item and insert it before the Nth-from-top position. The `dupN` instructions (e.g., `dup2` to `dup9`, with `dup` acting as `dup1`) pop N items from the stack and then push them back twice in their original order.

---
<a href="https://cursor.com/background-agent?bcId=bc-0aed5696-ab19-4d44-b447-a24b556c58ff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0aed5696-ab19-4d44-b447-a24b556c58ff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

