### PR TITLE
Add debug instruction to show stack

### DIFF
--- a/src/interpreter.htm
+++ b/src/interpreter.htm
@@ -651,7 +651,7 @@ function runWithOutput(src, debug = false, opts = {}) {
 			inst++;
 			if (debug) console.log(`[T${th.id}] ${tok} [${S.join(',')}]`);
 			// primitives
-			if (["+", "-", "*", "/", "dup", "swap", "drop", "out", "bit", "bval", "prune"].includes(tok) || (tok.startsWith("dup") && tok.length === 4) || (tok.startsWith("swap") && tok.length === 5)) {
+			if (["+", "-", "*", "/", "dup", "swap", "drop", "out", "debug", "bit", "bval", "prune"].includes(tok) || (tok.startsWith("dup") && tok.length === 4) || (tok.startsWith("swap") && tok.length === 5)) {
 				if (tok === "dup") {
 					const v = pop();
 					S.push(v, v);
@@ -702,6 +702,11 @@ function runWithOutput(src, debug = false, opts = {}) {
 					vals.push(v);
 					cols.push(palette[idx]);
 					tips.push(`T${th.id}${cs?" @"+cs:""}`);
+				}
+				else if (tok === "debug") {
+					if (!dryRun) {
+						try { alert(S.join(' ')); } catch (e) { /* no-op */ }
+					}
 				} else {
 					let b = pop(),
 						a = pop(),


### PR DESCRIPTION
Add a `debug` instruction to the Forth interpreter to alert the current stack for debugging purposes.

---
<a href="https://cursor.com/background-agent?bcId=bc-78e2861c-f893-435f-9813-ad26863b64d3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-78e2861c-f893-435f-9813-ad26863b64d3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

